### PR TITLE
#24 - 잘못된 도메인 정보 바로 잡기

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -48,7 +48,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("kurt", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newKurt", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // When


### PR DESCRIPTION
회원 계정의 `user_id`에 UK 적용 완료

This closes #24 